### PR TITLE
Add LMDB-backed RGW usage metrics

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -4006,6 +4006,20 @@ options:
   default: 3
   services:
   - rgw
+- name: rgw_usage_metrics_db_path
+  type: str
+  level: advanced
+  desc: Path to LMDB database storing usage metrics
+  default: /var/lib/ceph/radosgw/usage
+  services:
+  - rgw
+- name: rgw_usage_metrics_refresh_interval
+  type: uint
+  level: advanced
+  desc: Seconds between usage metrics refresh
+  default: 60
+  services:
+  - rgw
 - name: rgw_luarocks_location
   type: str
   level: advanced

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -134,6 +134,7 @@ set(librgw_common_srcs
   rgw_sts.cc
   rgw_rest_sts.cc
   rgw_perf_counters.cc
+  rgw_usage_metrics.cc
   rgw_rest_oidc_provider.cc
   rgw_rest_iam.cc
   rgw_object_lock.cc

--- a/src/rgw/rgw_main.h
+++ b/src/rgw/rgw_main.h
@@ -30,6 +30,7 @@
 #include "rgw_lua.h"
 #include "rgw_dmclock_scheduler_ctx.h"
 #include "rgw_ratelimit.h"
+#include "rgw_usage_metrics.h"
 
 
 class RGWPauser : public RGWRealmReloader::Pauser {
@@ -80,6 +81,7 @@ class AppMain {
   std::unique_ptr<RGWFrontendPauser> fe_pauser;
   std::unique_ptr<RGWRealmWatcher> realm_watcher;
   std::unique_ptr<RGWPauser> rgw_pauser;
+  std::unique_ptr<UsageMetrics> usage_metrics;
   std::unique_ptr<sal::ConfigStore> cfgstore;
   SiteConfig site;
   const DoutPrefixProvider* dpp;

--- a/src/rgw/rgw_perf_counters.h
+++ b/src/rgw/rgw_perf_counters.h
@@ -92,6 +92,13 @@ enum {
   l_rgw_topic_last
 };
 
+enum {
+  l_rgw_usage_first = 18000,
+  l_rgw_usage_used_bytes,
+  l_rgw_usage_num_objects,
+  l_rgw_usage_last
+};
+
 namespace rgw::op_counters {
 
 struct CountersContainer {

--- a/src/rgw/rgw_usage_metrics.cc
+++ b/src/rgw/rgw_usage_metrics.cc
@@ -1,0 +1,113 @@
+#include "rgw_usage_metrics.h"
+#include "common/dout.h"
+#include "common/perf_counters.h"
+#include "rgw_sal.h"
+
+#define dout_subsys ceph_subsys_rgw
+
+namespace rgw {
+
+static std::shared_ptr<PerfCounters> create_usage_counters(const std::string& name, CephContext* cct) {
+  PerfCountersBuilder pcb(cct, name, l_rgw_usage_first, l_rgw_usage_last);
+  pcb.set_prio_default(PerfCountersBuilder::PRIO_USEFUL);
+  pcb.add_u64_counter(l_rgw_usage_used_bytes, "used_bytes", "Used bytes");
+  pcb.add_u64_counter(l_rgw_usage_num_objects, "num_objects", "Number of objects");
+  auto pc = pcb.create_perf_counters();
+  cct->get_perfcounters_collection()->add(pc);
+  return std::shared_ptr<PerfCounters>(pc);
+}
+
+UsageMetrics::UsageMetrics(CephContext *cct) : cct(cct) {}
+
+UsageMetrics::~UsageMetrics() {
+  stop();
+}
+
+int UsageMetrics::start(rgw::sal::Driver *d) {
+  driver = d;
+  interval = cct->_conf->get_val<uint64_t>("rgw_usage_metrics_refresh_interval");
+  std::string path = cct->_conf->get_val<std::string>("rgw_usage_metrics_db_path");
+  int r = mdb_env_create(&env);
+  if (r == 0) r = mdb_env_set_maxdbs(env, 1);
+  if (r == 0) r = mdb_env_open(env, path.c_str(), 0, 0664);
+  if (r != 0) {
+    ldout(cct, 1) << "failed to open usage lmdb: " << cpp_strerror(r) << dendl;
+    if (env) mdb_env_close(env);
+    env = nullptr;
+    return -r;
+  }
+  MDB_txn *txn;
+  r = mdb_txn_begin(env, nullptr, 0, &txn);
+  if (r == 0) {
+    r = mdb_dbi_open(txn, "usage", MDB_CREATE, &dbi);
+    if (r == 0)
+      r = mdb_txn_commit(txn);
+    else
+      mdb_txn_abort(txn);
+  }
+  if (r != 0) {
+    ldout(cct, 1) << "failed to open usage db: " << cpp_strerror(r) << dendl;
+    mdb_env_close(env);
+    env = nullptr;
+    return -r;
+  }
+
+  user_cache = new PerfCountersCache(cct, 1024, create_usage_counters);
+  bucket_cache = new PerfCountersCache(cct, 1024, create_usage_counters);
+
+  stop_flag = false;
+  thr = std::thread(&UsageMetrics::background, this);
+  return 0;
+}
+
+void UsageMetrics::stop() {
+  stop_flag = true;
+  if (thr.joinable())
+    thr.join();
+  if (env) {
+    mdb_env_close(env);
+    env = nullptr;
+  }
+  delete user_cache;
+  user_cache = nullptr;
+  delete bucket_cache;
+  bucket_cache = nullptr;
+}
+
+void UsageMetrics::update_counter(const std::string& key, uint64_t bytes, uint64_t objs) {
+  PerfCountersCache *cache = key.rfind("user:",0) == 0 ? user_cache : bucket_cache;
+  if (cache) {
+    cache->set_counter(key, l_rgw_usage_used_bytes, bytes);
+    cache->set_counter(key, l_rgw_usage_num_objects, objs);
+  }
+}
+
+void UsageMetrics::load_from_db() {
+  if (!env) return;
+  MDB_txn *txn;
+  if (mdb_txn_begin(env, nullptr, MDB_RDONLY, &txn) != 0)
+    return;
+  MDB_cursor *cursor;
+  if (mdb_cursor_open(txn, dbi, &cursor) == 0) {
+    MDB_val k, v;
+    while (mdb_cursor_get(cursor, &k, &v, MDB_NEXT) == 0) {
+      std::string key(static_cast<char*>(k.mv_data), k.mv_size);
+      if (v.mv_size == sizeof(uint64_t)*2) {
+        const uint64_t* vals = static_cast<const uint64_t*>(v.mv_data);
+        update_counter(key, vals[0], vals[1]);
+      }
+    }
+    mdb_cursor_close(cursor);
+  }
+  mdb_txn_abort(txn);
+}
+
+void UsageMetrics::background() {
+  ceph_pthread_setname("usage_metrics");
+  while (!stop_flag) {
+    load_from_db();
+    sleep(interval);
+  }
+}
+
+} // namespace rgw

--- a/src/rgw/rgw_usage_metrics.h
+++ b/src/rgw/rgw_usage_metrics.h
@@ -1,0 +1,39 @@
+#ifndef RGW_USAGE_METRICS_H
+#define RGW_USAGE_METRICS_H
+
+#include <string>
+#include <thread>
+#include <atomic>
+#include <lmdb.h>
+#include "common/ceph_context.h"
+#include "rgw_perf_counters.h"
+#include "common/perf_counters_cache.h"
+#include "rgw_sal_fwd.h"
+
+namespace rgw {
+
+class UsageMetrics {
+  CephContext *cct{nullptr};
+  rgw::sal::Driver *driver{nullptr};
+  MDB_env *env{nullptr};
+  MDB_dbi dbi{0};
+  std::thread thr;
+  std::atomic<bool> stop_flag{false};
+  PerfCountersCache *user_cache{nullptr};
+  PerfCountersCache *bucket_cache{nullptr};
+  uint64_t interval{60};
+
+  void background();
+  void load_from_db();
+  void update_counter(const std::string& key, uint64_t bytes, uint64_t objs);
+public:
+  explicit UsageMetrics(CephContext *cct);
+  ~UsageMetrics();
+
+  int start(rgw::sal::Driver *driver);
+  void stop();
+};
+
+} // namespace rgw
+
+#endif


### PR DESCRIPTION
## Summary
- track RGW usage metrics via new perf counters
- store usage stats in LMDB database
- refresh metrics in a background thread


