### PR TITLE
Add RGW usage metrics exporter

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -4203,6 +4203,14 @@ options:
   see_also:
   - rgw_bucket_counters_cache
   with_legacy: true
+- name: rgw_usage_cache_refresh_interval
+  type: uint
+  level: advanced
+  desc: Interval in seconds between usage cache refreshes
+  default: 43200
+  services:
+  - rgw
+  with_legacy: true
 - name: rgw_kafka_connection_idle
   type: uint 
   level: advanced

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -134,6 +134,9 @@ set(librgw_common_srcs
   rgw_sts.cc
   rgw_rest_sts.cc
   rgw_perf_counters.cc
+  rgw_exporter.cc
+  rgw_usage_cache.cc
+  rgw_usage_manager.cc
   rgw_rest_oidc_provider.cc
   rgw_rest_iam.cc
   rgw_object_lock.cc

--- a/src/rgw/rgw_exporter.cc
+++ b/src/rgw/rgw_exporter.cc
@@ -1,0 +1,24 @@
+#include "rgw_exporter.h"
+#include "common/ceph_context.h"
+#include <filesystem>
+
+int RGWExporter::start(const DoutPrefixProvider* dpp, rgw::sal::Driver* driver)
+{
+  auto cct = dpp->get_cct();
+  std::string path = cct->_conf.get_val<std::string>("rgw_data") + "/usage_cache";
+  std::filesystem::create_directories(path);
+  cache = std::make_unique<RGWUsageCache>(path);
+  manager = std::make_unique<RGWUsageManager>(dpp, driver, cache.get());
+  manager->start();
+  return 0;
+}
+
+void RGWExporter::stop()
+{
+  if (manager) {
+    manager->stop();
+    manager.reset();
+  }
+  cache.reset();
+}
+

--- a/src/rgw/rgw_exporter.h
+++ b/src/rgw/rgw_exporter.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "rgw_usage_cache.h"
+#include "rgw_usage_manager.h"
+
+class RGWExporter {
+  std::unique_ptr<RGWUsageCache> cache;
+  std::unique_ptr<RGWUsageManager> manager;
+public:
+  int start(const DoutPrefixProvider* dpp, rgw::sal::Driver* driver);
+  void stop();
+};

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -151,6 +151,8 @@ int main(int argc, char *argv[])
     return -r;
   }
 
+  main.init_usage_exporter();
+
   main.cond_init_apis();
 
   mutex.lock();

--- a/src/rgw/rgw_main.h
+++ b/src/rgw/rgw_main.h
@@ -18,6 +18,7 @@
 #include <vector>
 #include <map>
 #include <string>
+#include "rgw_exporter.h"
 
 #include "common/async/context_pool.h"
 
@@ -86,6 +87,7 @@ class AppMain {
   RGWProcessEnv env;
   void need_context_pool();
   std::optional<ceph::async::io_context_pool> context_pool;
+  std::unique_ptr<RGWExporter> exporter;
 public:
   AppMain(const DoutPrefixProvider* dpp);
   ~AppMain();
@@ -115,6 +117,7 @@ public:
   int init_frontends2(RGWLib* rgwlib = nullptr);
   void init_tracepoints();
   void init_lua();
+  void init_usage_exporter();
 
   bool have_http() {
     return have_http_frontend;

--- a/src/rgw/rgw_perf_counters.h
+++ b/src/rgw/rgw_perf_counters.h
@@ -92,6 +92,17 @@ enum {
   l_rgw_topic_last
 };
 
+enum {
+  l_rgw_usage_first = 18000,
+
+  l_rgw_bucket_used_bytes,
+  l_rgw_bucket_num_objects,
+  l_rgw_user_used_bytes,
+  l_rgw_user_num_objects,
+
+  l_rgw_usage_last
+};
+
 namespace rgw::op_counters {
 
 struct CountersContainer {
@@ -108,6 +119,13 @@ void tinc(const CountersContainer &counters, int idx, utime_t);
 void tinc(const CountersContainer &counters, int idx, ceph::timespan amt);
 
 } // namespace rgw::op_counters
+
+namespace rgw::usage_counters {
+extern ceph::perf_counters::PerfCountersCache *user_usage_cache;
+extern ceph::perf_counters::PerfCountersCache *bucket_usage_cache;
+extern const std::string rgw_user_usage_counters_key;
+extern const std::string rgw_bucket_usage_counters_key;
+}
 
 namespace rgw::persistent_topic_counters {
 

--- a/src/rgw/rgw_usage_cache.cc
+++ b/src/rgw/rgw_usage_cache.cc
@@ -1,0 +1,86 @@
+#include "rgw_usage_cache.h"
+#include <sys/stat.h>
+#include <cstring>
+
+struct usage_record {
+  uint64_t bytes;
+  uint64_t objects;
+};
+
+RGWUsageCache::RGWUsageCache(const std::string& path)
+{
+  mkdir(path.c_str(), 0755);
+  mdb_env_create(&env);
+  mdb_env_set_maxdbs(env, 2);
+  mdb_env_set_mapsize(env, 1024*1024*10);
+  mdb_env_open(env, path.c_str(), 0, 0644);
+  MDB_txn* txn;
+  mdb_txn_begin(env, nullptr, 0, &txn);
+  mdb_dbi_open(txn, "users", MDB_CREATE, &user_dbi);
+  mdb_dbi_open(txn, "buckets", MDB_CREATE, &bucket_dbi);
+  mdb_txn_commit(txn);
+}
+
+RGWUsageCache::~RGWUsageCache()
+{
+  if (env) {
+    mdb_dbi_close(env, user_dbi);
+    mdb_dbi_close(env, bucket_dbi);
+    mdb_env_close(env);
+  }
+}
+
+static int put(MDB_env* env, MDB_dbi dbi, const std::string& key, uint64_t bytes, uint64_t objects)
+{
+  MDB_txn* txn;
+  int r = mdb_txn_begin(env, nullptr, 0, &txn);
+  if (r != 0) return r;
+  usage_record rec{bytes, objects};
+  MDB_val k{(void*)key.data(), key.size()};
+  MDB_val v{&rec, sizeof(rec)};
+  r = mdb_put(txn, dbi, &k, &v, 0);
+  if (r == 0)
+    r = mdb_txn_commit(txn);
+  else
+    mdb_txn_abort(txn);
+  return r;
+}
+
+static bool get(MDB_env* env, MDB_dbi dbi, const std::string& key, uint64_t& bytes, uint64_t& objects)
+{
+  MDB_txn* txn;
+  if (mdb_txn_begin(env, nullptr, MDB_RDONLY, &txn) != 0)
+    return false;
+  MDB_val k{(void*)key.data(), key.size()};
+  MDB_val v;
+  int r = mdb_get(txn, dbi, &k, &v);
+  if (r == 0 && v.mv_size == sizeof(usage_record)) {
+    usage_record rec;
+    std::memcpy(&rec, v.mv_data, sizeof(rec));
+    bytes = rec.bytes;
+    objects = rec.objects;
+  }
+  mdb_txn_abort(txn);
+  return r == 0;
+}
+
+int RGWUsageCache::put_user(const std::string& id, uint64_t b, uint64_t o)
+{
+  return put(env, user_dbi, id, b, o);
+}
+
+int RGWUsageCache::put_bucket(const std::string& name, uint64_t b, uint64_t o)
+{
+  return put(env, bucket_dbi, name, b, o);
+}
+
+bool RGWUsageCache::get_user(const std::string& id, uint64_t& b, uint64_t& o)
+{
+  return get(env, user_dbi, id, b, o);
+}
+
+bool RGWUsageCache::get_bucket(const std::string& name, uint64_t& b, uint64_t& o)
+{
+  return get(env, bucket_dbi, name, b, o);
+}
+

--- a/src/rgw/rgw_usage_cache.h
+++ b/src/rgw/rgw_usage_cache.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <string>
+#include <lmdb.h>
+#include <cstdint>
+
+class RGWUsageCache {
+  MDB_env* env = nullptr;
+  MDB_dbi user_dbi = 0;
+  MDB_dbi bucket_dbi = 0;
+public:
+  RGWUsageCache(const std::string& path);
+  ~RGWUsageCache();
+  int put_user(const std::string& id, uint64_t bytes, uint64_t objects);
+  int put_bucket(const std::string& name, uint64_t bytes, uint64_t objects);
+  bool get_user(const std::string& id, uint64_t& bytes, uint64_t& objects);
+  bool get_bucket(const std::string& name, uint64_t& bytes, uint64_t& objects);
+};

--- a/src/rgw/rgw_usage_manager.cc
+++ b/src/rgw/rgw_usage_manager.cc
@@ -1,0 +1,90 @@
+#include "rgw_usage_manager.h"
+#include "rgw_user.h"
+#include <chrono>
+
+using namespace std::chrono_literals;
+using rgw::usage_counters::user_usage_cache;
+using rgw::usage_counters::bucket_usage_cache;
+using rgw::usage_counters::rgw_user_usage_counters_key;
+using rgw::usage_counters::rgw_bucket_usage_counters_key;
+
+RGWUsageManager::RGWUsageManager(const DoutPrefixProvider* dpp,
+                                 rgw::sal::Driver* driver,
+                                 RGWUsageCache* cache)
+  : dpp(dpp), driver(driver), cache(cache)
+{
+  interval = dpp->get_cct()->_conf.get_val<uint64_t>("rgw_usage_cache_refresh_interval");
+}
+
+RGWUsageManager::~RGWUsageManager()
+{
+  stop();
+}
+
+void RGWUsageManager::start()
+{
+  stop_flag = false;
+  thr = std::thread(&RGWUsageManager::run, this);
+}
+
+void RGWUsageManager::stop()
+{
+  stop_flag = true;
+  if (thr.joinable())
+    thr.join();
+}
+
+void RGWUsageManager::run()
+{
+  while (!stop_flag) {
+    refresh();
+    for (unsigned i=0; i<interval && !stop_flag; ++i) {
+      std::this_thread::sleep_for(1s);
+    }
+  }
+}
+
+void RGWUsageManager::refresh()
+{
+  void* handle = nullptr;
+  int r = driver->meta_list_keys_init(dpp, "user", std::string(), &handle);
+  if (r < 0)
+    return;
+  bool truncated = false;
+  do {
+    std::list<std::string> keys;
+    r = driver->meta_list_keys_next(dpp, handle, 1000, keys, &truncated);
+    if (r < 0 && r != -ENOENT) {
+      break;
+    }
+    for (auto& id : keys) {
+      auto user = driver->get_user(rgw_user(id));
+      if (!user)
+        continue;
+      if (user->load_user(dpp, null_yield) < 0)
+        continue;
+      std::map<std::string, bucket_meta_entry> buckets;
+      if (rgw_user_get_all_buckets_stats(dpp, driver, user.get(), buckets, null_yield) < 0)
+        continue;
+      uint64_t total_b = 0, total_o = 0;
+      for (auto& it : buckets) {
+        total_b += it.second.size;
+        total_o += it.second.count;
+        cache->put_bucket(it.first, it.second.size, it.second.count);
+        if (bucket_usage_cache) {
+          std::string key = ceph::perf_counters::key_create(rgw_bucket_usage_counters_key, {{"Bucket", it.first}});
+          bucket_usage_cache->set_counter(key, l_rgw_bucket_used_bytes, it.second.size);
+          bucket_usage_cache->set_counter(key, l_rgw_bucket_num_objects, it.second.count);
+        }
+      }
+      cache->put_user(id, total_b, total_o);
+      if (user_usage_cache) {
+        std::string key = ceph::perf_counters::key_create(rgw_user_usage_counters_key, {{"User", id}});
+        user_usage_cache->set_counter(key, l_rgw_user_used_bytes, total_b);
+        user_usage_cache->set_counter(key, l_rgw_user_num_objects, total_o);
+      }
+    }
+  } while (truncated);
+  driver->meta_list_keys_complete(handle);
+}
+

--- a/src/rgw/rgw_usage_manager.h
+++ b/src/rgw/rgw_usage_manager.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "rgw_usage_cache.h"
+#include "rgw_perf_counters.h"
+#include "rgw_sal.h"
+#include "include/Context.h"
+#include <thread>
+#include <atomic>
+
+class RGWUsageManager {
+  const DoutPrefixProvider* dpp;
+  rgw::sal::Driver* driver;
+  RGWUsageCache* cache;
+  std::thread thr;
+  std::atomic<bool> stop_flag{false};
+  unsigned interval;
+
+  void run();
+  void refresh();
+
+public:
+  RGWUsageManager(const DoutPrefixProvider* dpp, rgw::sal::Driver* driver,
+                  RGWUsageCache* cache);
+  ~RGWUsageManager();
+  void start();
+  void stop();
+};

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -357,6 +357,11 @@ target_compile_definitions(unittest_rgw_posix_driver PUBLIC LMDB_SAFE_NO_CPP_UTI
 target_include_directories(unittest_rgw_posix_driver
   SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw"
   SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw/driver/posix")
-target_link_libraries(unittest_rgw_posix_driver  ${UNITTEST_LIBS}
+  target_link_libraries(unittest_rgw_posix_driver  ${UNITTEST_LIBS}
   ${rgw_libs} ${LMDB_LIBRARIES})
 endif(WITH_RADOSGW_POSIX)
+
+add_executable(unittest_rgw_usage_exporter
+        test_rgw_usage_exporter.cc)
+add_ceph_unittest(unittest_rgw_usage_exporter)
+target_link_libraries(unittest_rgw_usage_exporter ${UNITTEST_LIBS} ${rgw_libs} ${LMDB_LIBRARIES})

--- a/src/test/rgw/test_rgw_usage_exporter.cc
+++ b/src/test/rgw/test_rgw_usage_exporter.cc
@@ -1,0 +1,19 @@
+#include "rgw_usage_cache.h"
+#include <gtest/gtest.h>
+#include <filesystem>
+
+TEST(RGWUsageCache, PutGet) {
+  std::string dir = std::filesystem::temp_directory_path() / "rgw_usage_test";
+  std::filesystem::remove_all(dir);
+  RGWUsageCache cache(dir);
+  ASSERT_EQ(0, cache.put_user("u", 10, 2));
+  ASSERT_EQ(0, cache.put_bucket("b", 5, 1));
+  uint64_t bytes=0, objs=0;
+  ASSERT_TRUE(cache.get_user("u", bytes, objs));
+  ASSERT_EQ(10u, bytes);
+  ASSERT_EQ(2u, objs);
+  ASSERT_TRUE(cache.get_bucket("b", bytes, objs));
+  ASSERT_EQ(5u, bytes);
+  ASSERT_EQ(1u, objs);
+}
+


### PR DESCRIPTION
## Summary
- introduce `rgw_usage_cache_refresh_interval` option
- implement LMDB-backed usage cache and background manager
- expose bucket and user usage metrics via perf counters
- start/stop new exporter in RGW lifecycle
- add unit test for RGWUsageCache

## Testing
- `git status --short`
- *No tests run due to environment limitations*


