### PR TITLE
Add RGW usage metrics exporter and LMDB cache

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -134,6 +134,8 @@ set(librgw_common_srcs
   rgw_sts.cc
   rgw_rest_sts.cc
   rgw_perf_counters.cc
+  rgw_usage_cache.cc
+  rgw_exporter.cc
   rgw_rest_oidc_provider.cc
   rgw_rest_iam.cc
   rgw_object_lock.cc

--- a/src/rgw/rgw_exporter.cc
+++ b/src/rgw/rgw_exporter.cc
@@ -1,0 +1,56 @@
+#include "rgw_exporter.h"
+
+#include <chrono>
+#include <utility>
+
+#include "common/perf_counters_key.h"
+
+using namespace std::chrono_literals;
+using namespace rgw::usage_counters;
+
+RGWExporter::RGWExporter(CephContext* cct, RGWUsageCache* cache)
+  : cct(cct), cache(cache) {}
+
+RGWExporter::~RGWExporter() {
+  stop();
+}
+
+void RGWExporter::start() {
+  stop_requested = false;
+  worker = std::thread(&RGWExporter::run, this);
+}
+
+void RGWExporter::stop() {
+  stop_requested = true;
+  if (worker.joinable()) {
+    worker.join();
+  }
+}
+
+void RGWExporter::run() {
+  while (!stop_requested) {
+    refresh();
+    std::this_thread::sleep_for(1s);
+  }
+}
+
+void RGWExporter::refresh() {
+  /* Placeholder for reading usage from metadata and updating counters */
+}
+
+void RGWExporter::update_user(const std::string& user, const RGWUsageRecord& record) {
+  if (!user_usage_counters_cache)
+    return;
+  std::string key = ceph::perf_counters::key_create(rgw_user_usage_counters_key, {{"user", user}});
+  user_usage_counters_cache->set_counter(key, l_rgw_usage_user_used_bytes, record.used_bytes);
+  user_usage_counters_cache->set_counter(key, l_rgw_usage_user_num_objects, record.num_objects);
+}
+
+void RGWExporter::update_bucket(const std::string& bucket, const RGWUsageRecord& record) {
+  if (!bucket_usage_counters_cache)
+    return;
+  std::string key = ceph::perf_counters::key_create(rgw_bucket_usage_counters_key, {{"bucket", bucket}});
+  bucket_usage_counters_cache->set_counter(key, l_rgw_usage_bucket_used_bytes, record.used_bytes);
+  bucket_usage_counters_cache->set_counter(key, l_rgw_usage_bucket_num_objects, record.num_objects);
+}
+

--- a/src/rgw/rgw_exporter.h
+++ b/src/rgw/rgw_exporter.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <atomic>
+#include <thread>
+#include <string>
+
+#include "rgw_usage_cache.h"
+#include "rgw_perf_counters.h"
+
+class RGWExporter {
+  CephContext* cct;
+  RGWUsageCache* cache;
+  std::thread worker;
+  std::atomic<bool> stop_requested{false};
+
+  void run();
+  void refresh();
+
+public:
+  RGWExporter(CephContext* cct, RGWUsageCache* cache = nullptr);
+  ~RGWExporter();
+
+  void start();
+  void stop();
+
+  void update_user(const std::string& user, const RGWUsageRecord& record);
+  void update_bucket(const std::string& bucket, const RGWUsageRecord& record);
+};
+

--- a/src/rgw/rgw_lib.cc
+++ b/src/rgw/rgw_lib.cc
@@ -527,6 +527,7 @@ namespace rgw {
       return -EIO;
     }
 
+    main.init_usage_exporter();
     main.cond_init_apis();
 
     mutex.lock();

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -151,6 +151,7 @@ int main(int argc, char *argv[])
     return -r;
   }
 
+  main.init_usage_exporter();
   main.cond_init_apis();
 
   mutex.lock();

--- a/src/rgw/rgw_main.h
+++ b/src/rgw/rgw_main.h
@@ -57,6 +57,7 @@ namespace lua { class Background; }
 namespace sal { class ConfigStore; }
 
 class RGWLib;
+class RGWExporter;
 class AppMain {
   /* several components should be initalized only if librgw is
     * also serving HTTP */
@@ -86,6 +87,7 @@ class AppMain {
   RGWProcessEnv env;
   void need_context_pool();
   std::optional<ceph::async::io_context_pool> context_pool;
+  std::unique_ptr<RGWExporter> usage_exporter;
 public:
   AppMain(const DoutPrefixProvider* dpp);
   ~AppMain();
@@ -112,6 +114,7 @@ public:
   void cond_init_apis();
   void init_ldap();
   void init_opslog();
+  void init_usage_exporter();
   int init_frontends2(RGWLib* rgwlib = nullptr);
   void init_tracepoints();
   void init_lua();

--- a/src/rgw/rgw_perf_counters.h
+++ b/src/rgw/rgw_perf_counters.h
@@ -92,6 +92,17 @@ enum {
   l_rgw_topic_last
 };
 
+enum {
+  l_rgw_usage_first = 18000,
+
+  l_rgw_usage_bucket_used_bytes,
+  l_rgw_usage_bucket_num_objects,
+  l_rgw_usage_user_used_bytes,
+  l_rgw_usage_user_num_objects,
+
+  l_rgw_usage_last
+};
+
 namespace rgw::op_counters {
 
 struct CountersContainer {
@@ -125,3 +136,12 @@ public:
 };
 
 } // namespace rgw::persistent_topic_counters
+
+namespace rgw::usage_counters {
+
+extern ceph::perf_counters::PerfCountersCache *user_usage_counters_cache;
+extern ceph::perf_counters::PerfCountersCache *bucket_usage_counters_cache;
+extern const std::string rgw_user_usage_counters_key;
+extern const std::string rgw_bucket_usage_counters_key;
+
+} // namespace rgw::usage_counters

--- a/src/rgw/rgw_usage_cache.cc
+++ b/src/rgw/rgw_usage_cache.cc
@@ -1,0 +1,73 @@
+#include "rgw_usage_cache.h"
+
+#include <cstring>
+
+RGWUsageCache::RGWUsageCache(const std::string& path) {
+  mdb_env_create(&env);
+  mdb_env_set_maxdbs(env, 2);
+  mdb_env_open(env, path.c_str(), MDB_NOSUBDIR, 0664);
+  MDB_txn* txn;
+  mdb_txn_begin(env, nullptr, 0, &txn);
+  mdb_dbi_open(txn, "user", MDB_CREATE, &user_dbi);
+  mdb_dbi_open(txn, "bucket", MDB_CREATE, &bucket_dbi);
+  mdb_txn_commit(txn);
+}
+
+RGWUsageCache::~RGWUsageCache() {
+  if (env) {
+    mdb_dbi_close(env, user_dbi);
+    mdb_dbi_close(env, bucket_dbi);
+    mdb_env_close(env);
+  }
+}
+
+int RGWUsageCache::put_user(const std::string& user, const RGWUsageRecord& record) {
+  MDB_txn* txn;
+  int r = mdb_txn_begin(env, nullptr, 0, &txn);
+  if (r != MDB_SUCCESS) return r;
+  MDB_val key{user.size(), const_cast<char*>(user.data())};
+  MDB_val val{sizeof(record), const_cast<RGWUsageRecord*>(&record)};
+  r = mdb_put(txn, user_dbi, &key, &val, 0);
+  if (r == MDB_SUCCESS) r = mdb_txn_commit(txn); else mdb_txn_abort(txn);
+  return r;
+}
+
+int RGWUsageCache::get_user(const std::string& user, RGWUsageRecord* record) {
+  MDB_txn* txn;
+  int r = mdb_txn_begin(env, nullptr, MDB_RDONLY, &txn);
+  if (r != MDB_SUCCESS) return r;
+  MDB_val key{user.size(), const_cast<char*>(user.data())};
+  MDB_val val;
+  r = mdb_get(txn, user_dbi, &key, &val);
+  if (r == MDB_SUCCESS && val.mv_size == sizeof(RGWUsageRecord)) {
+    std::memcpy(record, val.mv_data, sizeof(RGWUsageRecord));
+  }
+  mdb_txn_abort(txn);
+  return r;
+}
+
+int RGWUsageCache::put_bucket(const std::string& bucket, const RGWUsageRecord& record) {
+  MDB_txn* txn;
+  int r = mdb_txn_begin(env, nullptr, 0, &txn);
+  if (r != MDB_SUCCESS) return r;
+  MDB_val key{bucket.size(), const_cast<char*>(bucket.data())};
+  MDB_val val{sizeof(record), const_cast<RGWUsageRecord*>(&record)};
+  r = mdb_put(txn, bucket_dbi, &key, &val, 0);
+  if (r == MDB_SUCCESS) r = mdb_txn_commit(txn); else mdb_txn_abort(txn);
+  return r;
+}
+
+int RGWUsageCache::get_bucket(const std::string& bucket, RGWUsageRecord* record) {
+  MDB_txn* txn;
+  int r = mdb_txn_begin(env, nullptr, MDB_RDONLY, &txn);
+  if (r != MDB_SUCCESS) return r;
+  MDB_val key{bucket.size(), const_cast<char*>(bucket.data())};
+  MDB_val val;
+  r = mdb_get(txn, bucket_dbi, &key, &val);
+  if (r == MDB_SUCCESS && val.mv_size == sizeof(RGWUsageRecord)) {
+    std::memcpy(record, val.mv_data, sizeof(RGWUsageRecord));
+  }
+  mdb_txn_abort(txn);
+  return r;
+}
+

--- a/src/rgw/rgw_usage_cache.h
+++ b/src/rgw/rgw_usage_cache.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <string>
+#include <cstdint>
+#include <lmdb.h>
+
+struct RGWUsageRecord {
+  uint64_t used_bytes{0};
+  uint64_t num_objects{0};
+};
+
+class RGWUsageCache {
+  MDB_env* env{nullptr};
+  MDB_dbi user_dbi{};
+  MDB_dbi bucket_dbi{};
+public:
+  explicit RGWUsageCache(const std::string& path);
+  ~RGWUsageCache();
+
+  int put_user(const std::string& user, const RGWUsageRecord& record);
+  int get_user(const std::string& user, RGWUsageRecord* record);
+
+  int put_bucket(const std::string& bucket, const RGWUsageRecord& record);
+  int get_bucket(const std::string& bucket, RGWUsageRecord* record);
+};
+

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -297,6 +297,10 @@ target_include_directories(unittest_rgw_url
   SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw")
 target_link_libraries(unittest_rgw_url ${rgw_libs})
 
+add_executable(unittest_rgw_usage_exporter test_rgw_usage_exporter.cc)
+add_ceph_unittest(unittest_rgw_usage_exporter)
+target_link_libraries(unittest_rgw_usage_exporter ${UNITTEST_LIBS} ${rgw_libs} ${LMDB_LIBRARIES})
+
 add_executable(ceph_test_rgw_gc_log test_rgw_gc_log.cc $<TARGET_OBJECTS:unit-main>)
 target_include_directories(ceph_test_rgw_gc_log
   SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw")

--- a/src/test/rgw/test_rgw_usage_exporter.cc
+++ b/src/test/rgw/test_rgw_usage_exporter.cc
@@ -1,0 +1,25 @@
+#include "gtest/gtest.h"
+#include "rgw_usage_cache.h"
+
+#include <unistd.h>
+
+TEST(RGWUsageCache, PutGet) {
+  std::string path = "usage_cache_test.mdb";
+  ::unlink(path.c_str());
+  RGWUsageCache cache(path);
+  RGWUsageRecord urec{123, 2};
+  ASSERT_EQ(0, cache.put_user("user1", urec));
+  RGWUsageRecord out{};
+  ASSERT_EQ(0, cache.get_user("user1", &out));
+  EXPECT_EQ(urec.used_bytes, out.used_bytes);
+  EXPECT_EQ(urec.num_objects, out.num_objects);
+
+  RGWUsageRecord brec{456, 3};
+  ASSERT_EQ(0, cache.put_bucket("bucket1", brec));
+  ASSERT_EQ(0, cache.get_bucket("bucket1", &out));
+  EXPECT_EQ(brec.used_bytes, out.used_bytes);
+  EXPECT_EQ(brec.num_objects, out.num_objects);
+
+  ::unlink(path.c_str());
+}
+


### PR DESCRIPTION
## Summary
- track per-user and per-bucket usage via new PerfCounters
- implement LMDB-backed usage cache and exporter skeleton
- unit test LMDB put/get operations for usage cache

## Testing
- `g++ -std=c++17 src/rgw/rgw_usage_cache.cc src/test/rgw/test_rgw_usage_exporter.cc -I src -I src/rgw -I src/test -llmdb -lgtest -lgtest_main -lpthread -o /tmp/test_rgw_usage_exporter && /tmp/test_rgw_usage_exporter`
